### PR TITLE
Fix broken dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2604,13 +2604,12 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
-      "integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
-      "dev": true,
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "6.5.5",
-        "har-schema": "2.0.0"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -4363,7 +4362,7 @@
         "extend": "3.0.2",
         "forever-agent": "0.6.1",
         "form-data": "2.3.3",
-        "har-validator": "5.1.2",
+        "har-validator": "5.1.3",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",


### PR DESCRIPTION
Dependency har-validator 5.1.2 was throwing a 404 error leading to install issues -- bumping to 5.1.3 solved the problem for me. 

More info: https://github.com/ahmadnassri/node-har-validator/issues/113#issuecomment-438106000